### PR TITLE
Correct license in pyproject.toml to Apache-2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name        = "pyring_buffer"
 version     = "1.0.1"
-license     = {text = "MIT"}
+license     = {text = "Apache-2.0"}
 description = "A pure Python ring buffer for bytes"
 readme      = "README.md"
 authors     = [
@@ -16,7 +16,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Topic :: Text Processing :: Linguistic",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
The repository currently has inconsistent licensing information:  
- `LICENSE.md` states Apache 2.0  
- GitHub metadata shows Apache 2.0  
- `pyproject.toml` incorrectly states MIT  

This change updates `pyproject.toml` to Apache 2.0 so that all references match and removes the ambiguity.  
